### PR TITLE
Add return data on stats API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently the API is limited to 1,000 calls a day per IP.
 
 ## Resources
 * [unlocks.csv](/resources/unlocks.csv)
-
+* [perks.json](/resources/perks.json)
 ## Get Involved
 Get involved with the Deceit developer community by joining our [Discord server](https://discord.gg/deceit)! 
 Use the channel #api-discussion for support and any queries you may have about this service.

--- a/api/Stats.md
+++ b/api/Stats.md
@@ -34,9 +34,9 @@ https://deceit-live.baseline.gg/stats?userId=10
 | eloRank     | unsigned int                                                        | Position on the elo leaderboard                           |
 | repRank     | unsigned int                                                        | Position on the reputation leaderboard                    |
 | banner      | byte                                                                | Last season rank (offset from bronze 20)                  |
-| character   | [chracter enum](#character-enum)                                    | Currently selected character                              |
+| character   | [character enum](#character-enum)                                    | Currently selected character                              |
 | perks       | unsigned short array                                                | Array of currently selected perk ids                      |
-| loadout?    | [chracter enum](#character-enum) to [loadout](#user-loadout-format) | Key-value pair of character id to an unsigned short array |
+| loadout?    | [character enum](#character-enum) to [loadout](#user-loadout-format) | Key-value pair of character id to an unsigned short array |
 | stats?      | [stats struct](#user-stats-structure)                               | User statistics                                           |
 ###### User Stats Structure
 <!---

--- a/api/Stats.md
+++ b/api/Stats.md
@@ -16,7 +16,116 @@ https://deceit-live.baseline.gg/stats?userId=10
 # Return:
 200 (OK): A JSON object containing information about the player.
 
-_TODO: Add more information on the return format of this object._
+###### Player Structure
+| Field       | Type                                                                | Description                                               |
+| ----------- | ------------------------------------------------------------------- | --------------------------------------------------------- |
+| userId      | unsigned long                                                       | Deceit Id                                                 |
+| name        | string                                                              | In-game username                                          |
+| elo         | double                                                              | Ranked elo                                                |
+| rank        | byte                                                                | Current rank (offset from bronze 20)                      |
+| marks       | byte                                                                | Ranked marks (0 if rank is 20)                            |
+| experience  | unsigned long                                                       | All-time experience                                       |
+| level       | unsigned int                                                        | Current level (Without prestige)                          |  
+| prestige    | byte                                                                | Current prestige (max is 9)                               |
+| emblem      | unsigned short                                                      | Emblem Id                                                 |
+| reputation  | unsigned int                                                        | Reputation                                                |
+| dailyXp     | unsigned int                                                        | Experience received today                                 |
+| dailyXpRank | unsigned int                                                        | Position on the daily xp leaderboard                      |
+| eloRank     | unsigned int                                                        | Position on the elo leaderboard                           |
+| repRank     | unsigned int                                                        | Position on the reputation leaderboard                    |
+| banner      | byte                                                                | Last season rank (offset from bronze 20)                  |
+| character   | [chracter enum](#character-enum)                                    | Currently selected character                              |
+| perks       | unsigned short array                                                | Array of currently selected perk ids                      |
+| loadout?    | [chracter enum](#character-enum) to [loadout](#user-loadout-format) | Key-value pair of character id to an unsigned short array |
+| stats?      | [stats struct](#user-stats-structure)                               | User statistics                                           |
+###### User Stats Structure
+<!---
+1) Challenges
+2) Game Outcomes
+3) Gameplay
+4) Miscellaneous
+--->
+| Field                       | Type          | Description                                |
+| --------------------------- | ------------- | ------------------------------------------ |
+| s_challenges_completed_0    | unsigned int  | Easy challenges completed                  |
+| s_challenges_completed_1    | unsigned int  | Medium challenges completed                |
+| s_challenges_completed_2    | unsigned int  | Hard challenges completed                  |
+| s_challenges_completed_3    | unsigned int  | Very Hard challenges completed             |
+| s_challenge_chips_used_0    | unsigned int  | Challenges shared                          |
+| s_challenge_chips_used_1    | unsigned int  | Challenges boosted                         |
+| s_challenge_chips_used_2    | unsigned int  | Challenges rerolled                        |
+| s_challenge_chips_used_3    | unsigned int  | Challenges extended                        |
+| s_challenge_rewards_0       | unsigned int  | XP received from challenges                |
+| s_challenge_rewards_1       | unsigned int  | Loot booth tokens received from challenges |
+| s_challenge_rewards_2       | unsigned int  | GM credits received from challenges        |
+| s_challenge_rewards_4       | unsigned int  | Cosmetics received from challenges         |
+| s_challenge_rewards_5       | unsigned int  | Emblems received from challenges           |
+| s_challenge_rewards_6       | unsigned int  | Challenge chips received from challenges   |
+| s_challenge_rewards_7       | unsigned int  | Event points received from challenges      |
+| games_played                | unsigned int  | Total games played                         |
+| games_as_innocent           | unsigned int  | Games played as innocent                   |
+| escapes                     | unsigned int  | Times escaped                              |
+| s_total_wins_inno           | unsigned int  | Total wins as innocent                     |
+| failed_escapes              | unsigned int  | Total escapes failed                       |
+| s_total_losses_inno         | unsigned int  | Total losses as innocent                   |
+| games_as_infected           | unsigned int  | Infected games played                      |
+| escapes_prevented           | unsigned int  | Escapes Prevented                          |
+| s_total_wins_inf            | unsigned int  | Total wins as infected                     |
+| escapes_allowed             | unsigned int  | Innocents escaped from player              |
+| s_total_losses_inf          | unsigned int  | Total losses as infected                   |
+| innocent_killed_as_infected | unsigned int  | Innocents killed                           |
+| s_blood_drank               | unsigned int  | Blood drank                                |
+| s_fuses_used                | unsigned int  | Fuses used                                 |
+| s_lever_pulled              | unsigned int  | Levers pulled                              |
+| s_lever_broke               | unsigned int  | Levers broken                              |
+| s_obj_centre                | unsigned int  | Centre objectives taken                    |
+| s_obj_shoot                 | unsigned int  | Target practice objectives taken           |
+| s_obj_double                | unsigned int  | Double objectives taken                    |
+| s_obj_stolen                | unsigned int  | Objectives stolen                          |
+| s_executed                  | unsigned int  | Times executed                             |
+| s_executions                | unsigned int  | Innocents executed                         |
+| s_lethal_correct            | unsigned int  | Players correctly lethaled                 |
+| s_lethal_incorrect          | unsigned int  | Incorrectly lethaled players               |
+| s_lethald_correct           | unsigned int  | Times correctly lethaled                   |
+| s_lethald_incorrect         | unsigned int  | Times lethaled incorrectly                 |
+| s_votes_cast                | unsigned int  | Votes cast                                 |
+| s_votes_correct             | unsigned int  | Correctly voted out players                |
+| s_votes_incorrect           | unsigned int  | Incorrectly voted out players              |
+| s_voted_on_correct          | unsigned int  | Times voted out correctly                  |
+| s_voted_on_incorrect        | unsigned int  | Times voted out incorrectly                |
+| s_times_downed              | unsigned int  | Times downed                               |
+| s_downs                     | unsigned int  | Players downed                             |
+| down_infected_on_innocent   | unsigned int  | Infected downed as innocent                |
+| down_infected_on_infected   | unsigned int  | Infected downed as infected                |
+| down_innocent_on_innocent   | unsigned int  | Innocents downed as innocent               |
+| down_innocent_on_infected   | unsigned int  | Total downed innocents as infected         |
+| s_meters_moved              | unsigned long | Distance travelled in meters               |
+| time_played_in_game         | unsigned int  | Time played in-game (in seconds)           |
+| s_time_dark                 | unsigned int  | Time spent in dark (in seconds)            |
+###### User Loadout Format
+| Index | Type  | Description  |
+| ----- | ----- | ------------ |
+| 0     | short | Hair         |
+| 1     | short | Accessory    |
+| 2     | short | Clothes      |
+| 3     | short | Wristband    |
+| 4     | short | Pistol       |
+| 5     | short | Knife        |
+| 6     | short | Victory Pose |
+| 7     | short | Defeat Pose  |
+###### Character Enum
+| Character  | Value |
+| ---------- | ----- |
+| Alex       | 0     |
+| Chang      | 1     |
+| Lisa       | 2     |
+| Rachel     | 3     |
+| Hans       | 4     |
+| Nina       | 5     |
+| Experiment | 6     |
+| Yeti       | 7     |
+| Werewolf   | 8     |
+| Vampire    | 9     |
 
 400 (Bad Request): JSON object with an `error` field, usually indicates the id was malformed or not provided.
 

--- a/resources/perks.json
+++ b/resources/perks.json
@@ -1,0 +1,290 @@
+{
+  "0": null,
+  "1": {
+    "name": "Say Cheese",
+    "description": "Cameras provide an extra flash"
+  },
+  "2": {
+    "name": "Foresight",
+    "description": "Active objectives that are within 15 metres of you are waypointed, even if you didn’t help activate them"
+  },
+  "3": {
+    "name": "Bright Eyed",
+    "description": "See slightly better in the dark without using light sources"
+  },
+  "4": {
+    "name": "Adrenaline",
+    "description": "Move 10% faster in the dark"
+  },
+  "5": {
+    "name": "Backstabber",
+    "description": "Deal 10% more damage from behind targets"
+  },
+  "6": {
+    "name": "Unsung Hero",
+    "description": "You will be notified who took an objective that you’ve activated"
+  },
+  "7": {
+    "name": "Frisk",
+    "description": "You can see downed people’s items in their nametag"
+  },
+  "8": {
+    "name": "Interrogate",
+    "description": "If you're involved in a vote that passed there is a chance that you will be told if they were Infected. Only one person can be informed per passing vote."
+  },
+  "9": null,
+  "10": {
+    "name": "Second Chance",
+    "description": "When antidoting someone, nearby Terrors will become downed"
+  },
+  "11": {
+    "name": "Panic!",
+    "description": "15% increased movement speed when in gas and when the exit is open"
+  },
+  "12": null,
+  "13": {
+    "name": "Blood Thirsty",
+    "description": "In Terror form move 10% faster when moving towards Innocents that are carrying fuses"
+  },
+  "14": {
+    "name": "Stealth",
+    "description": "Transform in and out of Terror form quieter"
+  },
+  "15": null,
+  "16": null,
+  "17": {
+    "name": "Slasher",
+    "description": "Increased melee damage with the knife"
+  },
+  "18": {
+    "name": "Evasion",
+    "description": "Trackers last 50% less time on you"
+  },
+  "19": {
+    "name": "Scavenger",
+    "description": "You are more likely to find more ammo when picking it up"
+  },
+  "20": null,
+  "21": {
+    "name": "Bounce Back",
+    "description": "Regenerate health slowly over time"
+  },
+  "22": null,
+  "23": {
+    "name": "Come Prepared",
+    "description": "Spawn with 100% armour"
+  },
+  "24": {
+    "name": "Bullet Time",
+    "description": "Take 25% less damage in Terror form"
+  },
+  "25": {
+    "name": "Tread Lightly",
+    "description": "Terrors see your position for less time when they detect your movement"
+  },
+  "26": {
+    "name": "Surveillance",
+    "description": "If you revive someone you can see their position for 15 seconds"
+  },
+  "27": {
+    "name": "Stubborn",
+    "description": "Levers that you’ve activated require more damage to disable"
+  },
+  "28": null,
+  "29": {
+    "name": "Sixth Sense",
+    "description": "At night all accessible blood bags are highlighted to you"
+  },
+  "30": {
+    "name": "Every Last Drop",
+    "description": "If you respawn in human form you will lose only 1/2 a slice of Terror strength"
+  },
+  "31": {
+    "name": "Heightened Senses",
+    "description": "Terror sense highlights Innocents every 4 seconds instead of 5"
+  },
+  "32": {
+    "name": "Fun Sponge",
+    "description": "You gain half a slice of Terror strength from each objective you deactivate"
+  },
+  "33": {
+    "name": "Hoarder",
+    "description": "Consumable items on the floor are highlighted from further away"
+  },
+  "34": {
+    "name": "Escape Artist",
+    "description": "It takes 25% less time for the escape door to open if you’re the one to interact with it"
+  },
+  "35": {
+    "name": "Skedaddle",
+    "description": "Move 35% faster (decaying over 3 seconds) after downing Terrors"
+  },
+  "36": {
+    "name": "Borrowed Time",
+    "description": "Each fuse you put in a fuse box reduces the time it will take for the door to open by 2 seconds"
+  },
+  "37": {
+    "name": "Critical Thinking",
+    "description": "Guns deal 25% extra damage when hitting targets in the head"
+  },
+  "38": {
+    "name": "Loaded",
+    "description": "Start with a full ammo clip in your pistol"
+  },
+  "39": {
+    "name": "Eye Spy",
+    "description": "You can see nametags when close to people in the dark"
+  },
+  "40": {
+    "name": "Turbo Trap",
+    "description": "Place traps faster"
+  },
+  "41": {
+    "name": "Sleight Of Hand",
+    "description": "Reload weapons faster"
+  },
+  "42": {
+    "name": "Good Lighting",
+    "description": "Cameras are 10% more effective against Terrors"
+  },
+  "43": {
+    "name": "Head Start",
+    "description": "Each time you respawn you’ll have 25% armour"
+  },
+  "44": {
+    "name": "Blindfire",
+    "description": "Find it harder to see in the dark but deal 5% more damage"
+  },
+  "45": {
+    "name": "Try Hard",
+    "description": "If you’re the first person to complete an objective you get full health and armour"
+  },
+  "46": {
+    "name": "Trigger Happy",
+    "description": "Shoot weapons at a faster rate"
+  },
+  "47": {
+    "name": "Berserker",
+    "description": "When at less than or equal to 50% health you do 10% more damage"
+  },
+  "48": {
+    "name": "Magnetic Mag",
+    "description": "Bullets have a 20% chance of returning on hitting a target"
+  },
+  "49": {
+    "name": "Trust Issues",
+    "description": "When you pull a lever it takes 5 seconds before the objective becomes active giving you time to get to it first"
+  },
+  "50": {
+    "name": "Triggered",
+    "description": "Increased trap trigger and blast radius"
+  },
+  "51": {
+    "name": "Greedy",
+    "description": "Keep all your items when respawning"
+  },
+  "52": {
+    "name": "Blasé",
+    "description": "When downed, additional votes cast on you increase your respawn time by 4 seconds instead of 5"
+  },
+  "53": {
+    "name": "Please Sir",
+    "description": "After completing an objective you will briefly be shown the position of available levers to activate"
+  },
+  "54": {
+    "name": "Detective",
+    "description": "When looking at a taken blood bag you can see when it was drank by an infected"
+  },
+  "55": {
+    "name": "Mind Your Step",
+    "description": "Get an outline on traps when stood near them in human form"
+  },
+  "56": {
+    "name": "Surprise",
+    "description": "Gain a burst of movement speed when coming out of a vent"
+  },
+  "57": {
+    "name": "Weak Point",
+    "description": "There is a 10% chance when damaging a lever that it becomes instantly deactivated"
+  },
+  "58": {
+    "name": "Knowledge Is Power",
+    "description": "Gain half a slice of Terror strength when you pick up a diary entry"
+  },
+  "59": {
+    "name": "Life Leech",
+    "description": "Get full Terror health when you execute someone"
+  },
+  "60": {
+    "name": "Quiet Quencher",
+    "description": "Make less noise when you’re drinking from blood bags"
+  },
+  "61": {
+    "name": "Slowly Does It",
+    "description": "Traps require you to be closer to them before they’re triggered"
+  },
+  "62": {
+    "name": "Juggernaut",
+    "description": "In Terror form take 10% less damage but move 10% slower"
+  },
+  "63": {
+    "name": "Uncontrollable",
+    "description": "Transforming into Terror form takes less time"
+  },
+  "64": {
+    "name": "Step Up",
+    "description": "Other player's footsteps are louder to you in Terror form"
+  },
+  "65": {
+    "name": "Acquired Taste",
+    "description": "After drinking a blood bag you will briefly be shown other available blood bags"
+  },
+  "66": {
+    "name": "Vengeance",
+    "description": "After respawning in Terror form you can see the player that downed you for 5 seconds"
+  },
+  "67": {
+    "name": "Appetiser",
+    "description": "Start the game with half a slice of Terror strength"
+  },
+  "68": {
+    "name": "Fully Alert",
+    "description": "At full blood when the lights are on you can see the Innocents"
+  },
+  "69": {
+    "name": "Locked On",
+    "description": "Your Terror sense highlights players with fuses that aren’t running"
+  },
+  "70": {
+    "name": "Rage Refund",
+    "description": "Get a slice of Terror strength if someone you executed gets antidoted"
+  },
+  "71": {
+    "name": "Last Laugh",
+    "description": "When enraged and in Terror form you can see all Innocents"
+  },
+  "72": {
+    "name": "Impatient",
+    "description": "Respawn faster when downed in Terror form"
+  },
+  "73": {
+    "name": "Solar Powered",
+    "description": "Torches slowly recharge when the lights are on"
+  },
+  "74": {
+    "name": "Speedy Recovery",
+    "description": "Health packs also instantly heal for 25 upon pickup"
+  },
+  "75": {
+    "name": "Spotting",
+    "description": "Trackers can now be placed on blood bags, showing an outline of the blood bag's state. This tracker displays only to you and is destroyed upon taking damage."
+  },
+  "76": {
+    "name": "Redistribution",
+    "description": "You're able to pick your traps back up again"
+  },
+  "77": {
+    "name": "Revitalised",
+    "description": "Gain half a slice of blood when revived by an innocent player"
+  }
+}


### PR DESCRIPTION
Also added perks.json to resources as a key-value pair: (perk id:perk data).
Example:
```
"1": {
    "name": "Say Cheese",
    "description": "Cameras provide an extra flash"
}
```
